### PR TITLE
packages/launch-editor/get-args.js:  added vscodium support

### DIFF
--- a/packages/launch-editor/get-args.js
+++ b/packages/launch-editor/get-args.js
@@ -35,6 +35,7 @@ module.exports = function getArgumentsForPosition (
     case 'code':
     case 'code-insiders':
     case 'Code':
+    case 'vscodium':
       return ['-r', '-g', `${fileName}:${lineNumber}:${columnNumber}`]
     case 'appcode':
     case 'clion':

--- a/packages/launch-editor/get-args.js
+++ b/packages/launch-editor/get-args.js
@@ -35,7 +35,7 @@ module.exports = function getArgumentsForPosition (
     case 'code':
     case 'code-insiders':
     case 'Code':
-    case 'vscodium':
+    case 'codium':
       return ['-r', '-g', `${fileName}:${lineNumber}:${columnNumber}`]
     case 'appcode':
     case 'clion':


### PR DESCRIPTION
VSCodium is just like VS Code but without MS branding/telemetry/licensing
See https://github.com/VSCodium/vscodium