### PR TITLE
fix: detect Sublime Text 4 process

### DIFF
--- a/packages/launch-editor/editor-info/osx.js
+++ b/packages/launch-editor/editor-info/osx.js
@@ -5,6 +5,8 @@ module.exports = {
   '/Applications/Brackets.app/Contents/MacOS/Brackets': 'brackets',
   '/Applications/Sublime Text.app/Contents/MacOS/Sublime Text':
     '/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl',
+  '/Applications/Sublime Text.app/Contents/MacOS/sublime_text':
+    '/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl',
   '/Applications/Sublime Text 2.app/Contents/MacOS/Sublime Text 2':
     '/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl',
   '/Applications/Sublime Text Dev.app/Contents/MacOS/Sublime Text':


### PR DESCRIPTION
This pull request adds a new entry for __Sublime Text 4__, allowing `launch-editor` to detect a running instance of the editor in macOS.

This bug affects all dependencies, including Vite.js and Vue CLI.

### Replication Steps
- Open _Sublime Text 4_ in macOS
- Start a Vue CLI app or Vite.js app with Vue components
- Open Vue devtools, select a Vue component, and click _Open in editor_
- The running instance of the editor is not detected

FYI @Akryum