### PR TITLE
Replace chalk with picocolors

### DIFF
--- a/packages/launch-editor/index.js
+++ b/packages/launch-editor/index.js
@@ -11,7 +11,7 @@
 const fs = require('fs')
 const os = require('os')
 const path = require('path')
-const chalk = require('chalk')
+const colors = require('picocolors')
 const childProcess = require('child_process')
 
 const guessEditor = require('./guess')
@@ -21,14 +21,14 @@ function wrapErrorCallback (cb) {
   return (fileName, errorMessage) => {
     console.log()
     console.log(
-      chalk.red('Could not open ' + path.basename(fileName) + ' in the editor.')
+      colors.red('Could not open ' + path.basename(fileName) + ' in the editor.')
     )
     if (errorMessage) {
       if (errorMessage[errorMessage.length - 1] !== '.') {
         errorMessage += '.'
       }
       console.log(
-        chalk.red('The editor process exited with an error: ' + errorMessage)
+        colors.red('The editor process exited with an error: ' + errorMessage)
       )
     }
     console.log()

--- a/packages/launch-editor/package.json
+++ b/packages/launch-editor/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/yyx990803/launch-editor#readme",
   "dependencies": {
-    "chalk": "^2.3.0",
+    "picocolors": "^1.0.0",
     "shell-quote": "^1.6.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -218,7 +218,7 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
@@ -1797,6 +1797,11 @@ path-type@^2.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
   dependencies:
     pify "^2.0.0"
+
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
This is another take to make vite install size smaller.

Currently vite bundles two instances of chalk. v2 from this package
and v4 in own code.

Both are quite big

https://packagephobia.com/result?p=chalk@2.4.2
https://packagephobia.com/result?p=chalk@4.1.2

I suggest to replace it with micropackage which became quite popular
recently

https://packagephobia.com/result?p=picocolors
https://www.npmtrends.com/picocolors