### PR TITLE
fix(launch-editor): ignore output to stderr

### DIFF
--- a/packages/launch-editor/guess.js
+++ b/packages/launch-editor/guess.js
@@ -18,7 +18,11 @@ module.exports = function guessEditor (specifiedEditor) {
   // `Get-Process` on Windows
   try {
     if (process.platform === 'darwin') {
-      const output = childProcess.execSync('ps x').toString()
+      const output = childProcess
+        .execSync('ps x', {
+          stdio: ['pipe', 'pipe', 'ignore']
+        })
+        .toString()
       const processNames = Object.keys(COMMON_EDITORS_OSX)
       for (let i = 0; i < processNames.length; i++) {
         const processName = processNames[i]
@@ -51,7 +55,9 @@ module.exports = function guessEditor (specifiedEditor) {
       // x List all processes owned by you
       // -o comm Need only names column
       const output = childProcess
-        .execSync('ps x --no-heading -o comm --sort=comm')
+        .execSync('ps x --no-heading -o comm --sort=comm', {
+          stdio: ['pipe', 'pipe', 'ignore']
+        })
         .toString()
       const processNames = Object.keys(COMMON_EDITORS_LINUX)
       for (let i = 0; i < processNames.length; i++) {

--- a/packages/launch-editor/guess.js
+++ b/packages/launch-editor/guess.js
@@ -13,6 +13,11 @@ module.exports = function guessEditor (specifiedEditor) {
   if (specifiedEditor) {
     return shellQuote.parse(specifiedEditor)
   }
+
+  if (process.versions.webcontainer) {
+    return [process.env.EDITOR || "code"]
+  }
+  
   // We can find out which editor is currently running by:
   // `ps x` on macOS and Linux
   // `Get-Process` on Windows


### PR DESCRIPTION
Hi @yyx990803 👋 

I was testing the `vite-plugin-inspector` in StackBlitz and noticed that it prints `ps: command not found`. This is because currently we don't have `ps` available in the terminal.

<img width="308" alt="image" src="https://user-images.githubusercontent.com/1913805/168738849-e8c39fb7-80a2-45f1-a70f-52bd0bd6aa57.png">

However, we have `EDITOR` set to `code` so this plugin uses the fallback. I noticed that `stderr` is ignored for Windows but not for macOS or Linux. Maybe that's for a specific reason? This PR ignores the stderr stream.

----------------------------
As a small sidenote. To make the plugin resolve the right editor on StackBlitz even faster, we could add the following code block at the top of the `guessEditor` function.

```js
if (process.versions.webcontainer) {
    return [process.env.EDITOR];
}
```

The time to spawn the `ps` command is somewhat wasted because (a) it currently always fails, and (b) StackBlitz is a controlled environment which is identical for everyone.

I could add that block in this PR if you are interested in it or leave the code as is. Whatever you feel the most comfortable with.

Kind regards
Sam
