### PR TITLE
perf: use `Get-CimInstance` to guess editor on windows

### DIFF
--- a/packages/launch-editor/guess.js
+++ b/packages/launch-editor/guess.js
@@ -37,17 +37,15 @@ module.exports = function guessEditor (specifiedEditor) {
       }
     } else if (process.platform === 'win32') {
       const output = childProcess
-        .execSync('powershell -Command "Get-Process | Select-Object Path"', {
-          stdio: ['pipe', 'pipe', 'ignore']
-        })
+        .execSync(
+          'wmic process where "executablepath is not null" get executablepath',
+          {
+            stdio: ['pipe', 'pipe', 'ignore']
+          }
+        )
         .toString()
       const runningProcesses = output.split('\r\n')
       for (let i = 0; i < runningProcesses.length; i++) {
-        // `Get-Process` sometimes returns empty lines
-        if (!runningProcesses[i]) {
-          continue
-        }
-
         const fullProcessPath = runningProcesses[i].trim()
         const shortProcessName = path.basename(fullProcessPath)
 

--- a/packages/launch-editor/guess.js
+++ b/packages/launch-editor/guess.js
@@ -38,7 +38,7 @@ module.exports = function guessEditor (specifiedEditor) {
     } else if (process.platform === 'win32') {
       const output = childProcess
         .execSync(
-          'wmic process where "executablepath is not null" get executablepath',
+          'powershell -NoProfile -Command "Get-CimInstance -Query \\"select executablepath from win32_process where executablepath is not null\\" | % { $_.ExecutablePath }"',
           {
             stdio: ['pipe', 'pipe', 'ignore']
           }


### PR DESCRIPTION
~~Same change with https://github.com/facebook/create-react-app/pull/3808. It speeds up 12.5x on my PC.~~

~~[`wmic` is deprecated](https://docs.microsoft.com/en-us/windows/deployment/planning/windows-10-deprecated-features#:~:text=Windows%20Management%20Instrumentation%20Command%20line%20(WMIC)%20tool.) but it is fastest and the code is simplier. I tried using powershell but it seems it needs something like https://github.com/facebook/create-react-app/pull/2711 to archive the same speed as using `wmic`.~~

`wmic` is the fastest but [it is deprecated](https://docs.microsoft.com/en-us/windows/deployment/planning/windows-10-deprecated-features#:~:text=Windows%20Management%20Instrumentation%20Command%20line%20(WMIC)%20tool.) and could be removed by user. So I still used powershell. This PR speeds up 5x on my PC.

|Command|Time|
|-----------|-----|
|`powershell -Command "Get-Process \| Select-Object Path"` (current)|2000 - 2300ms|
|`powershell -NoProfile -Command "Get-Process \| Select-Object Path"`|1800 - 2000ms|
|`powershell -Command "Get-WmiObject -Class Win32_Process -Filter \"executablepath is not null\" -Property executablepath \| % { $_.ExecutablePath }"`|770 - 800ms|
|`powershell -NoProfile -Command "Get-WmiObject -Class Win32_Process -Filter \"executablepath is not null\" -Property executablepath \| % { $_.ExecutablePath }"`|310 - 330ms|
|`powershell -NoProfile -Command "Get-WmiObject  -Query \"select executablepath from win32_process where executablepath is not null\" \| % { $_.ExecutablePath }"`|290 - 300ms|
|`wmic process where "executablepath is not null" get executablepath`|160ms - 170ms|
