### PR TITLE
feat: Detect substring matches of executable for macOS

### DIFF
--- a/packages/launch-editor/guess.js
+++ b/packages/launch-editor/guess.js
@@ -24,15 +24,31 @@ module.exports = function guessEditor (specifiedEditor) {
   try {
     if (process.platform === 'darwin') {
       const output = childProcess
-        .execSync('ps x', {
+        .execSync('ps x -o comm=', {
           stdio: ['pipe', 'pipe', 'ignore']
         })
         .toString()
       const processNames = Object.keys(COMMON_EDITORS_OSX)
+      const processList = output.split('\n')
       for (let i = 0; i < processNames.length; i++) {
         const processName = processNames[i]
+        // Find editor by exact match.
         if (output.indexOf(processName) !== -1) {
           return [COMMON_EDITORS_OSX[processName]]
+        }
+        const processNameWithoutApplications = processName.replace('/Applications', '')
+        // Find editor installation not in /Applications.
+        if (output.indexOf(processNameWithoutApplications) !== -1) {
+          // Use the CLI command if one is specified
+          if (processName !== COMMON_EDITORS_OSX[processName]) {
+            return [COMMON_EDITORS_OSX[processName]]
+          }
+          // Use a partial match to find the running process path.  If one is found, use the
+          // existing path since it can be running from anywhere.
+          const runningProcess = processList.find((procName) => procName.endsWith(processNameWithoutApplications))
+          if (runningProcess !== undefined) {
+            return [runningProcess]
+          }
         }
       }
     } else if (process.platform === 'win32') {


### PR DESCRIPTION
This PR adds some less partial process detection of the application on macOS.  Applications are not always installed in `/Applications`, so this is an attempt at still identifying those applications.

I'm not sure if this causes any issues with any false matches, but I think it should be fine since exact matches are checked before partial matches.

Tested on macOS with WebStorm installed through JetBrains Toolbox with the install path below.
```
/Users/nrayburn/Library/Application Support/JetBrains/Toolbox/apps/WebStorm/ch0/222.3345.108/WebStorm.app/Contents/MacOS/webstorm
```

Fixes #45.