### PR TITLE
feat: customizable command via LAUNCH_EDITOR env

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,31 @@ To launch files, send requests to the server like the following:
 | `vim` | [Vim](http://www.vim.org/) |✓| | |
 | `visualstudio` | [Visual Studio](https://www.visualstudio.com/vs/) | | |✓|
 | `webstorm` | [WebStorm](https://www.jetbrains.com/webstorm/) |✓|✓|✓|
+
+### Custom editor support
+
+You can use the `LAUNCH_EDITOR` environment variable 
+
+#### to force a specific supported editor 
+
+```bash
+LAUNCH_EDITOR=codium
+```
+
+#### to run a custom launch script
+
+```bash
+LAUNCH_EDITOR=my-editor-launcher.sh
+```
+
+```shell
+# gets called with 3 args: filename, line, column
+filename=$1
+line=$2
+column=$3
+
+# call your editor with whatever args it expects
+my-editor -l $line -c $column -f $filename
+```
+
+

--- a/packages/launch-editor/get-args.js
+++ b/packages/launch-editor/get-args.js
@@ -53,6 +53,10 @@ module.exports = function getArgumentsForPosition (
       return ['--line', lineNumber, '--column', columnNumber, fileName]
   }
 
+  if (process.env.LAUNCH_EDITOR) {
+    return [fileName, lineNumber, columnNumber]
+  }
+
   // For all others, drop the lineNumber until we have
   // a mapping above, since providing the lineNumber incorrectly
   // can result in errors or confusing behavior.

--- a/packages/launch-editor/guess.js
+++ b/packages/launch-editor/guess.js
@@ -14,6 +14,10 @@ module.exports = function guessEditor (specifiedEditor) {
     return shellQuote.parse(specifiedEditor)
   }
 
+  if (process.env.LAUNCH_EDITOR) {
+    return [process.env.LAUNCH_EDITOR]
+  }
+
   if (process.versions.webcontainer) {
     return [process.env.EDITOR || 'code']
   }


### PR DESCRIPTION
slightly different implementation than #39 

The code changes are minimal, basically the LAUNCH_EDITOR value is used as first guess, bypassing scanning the process list.

In addition, it preserves `getArgumentsForPosition` support, so that users can use it to either force a specific supported editor via `LAUNCH_EDITOR=codium` or go full custom via `LAUNCH_EDITOR=custom-script.sh`
