### PR TITLE
fix: fix the problem of error when there are spaces in the path

### DIFF
--- a/packages/launch-editor/index.js
+++ b/packages/launch-editor/index.js
@@ -98,10 +98,10 @@ function launchEditor (file, specifiedEditor, onErrorCallback) {
   }
 
   if (lineNumber) {
-    const extraArgs = getArgumentsForPosition(editor, fileName, lineNumber, columnNumber)
+    const extraArgs = getArgumentsForPosition(editor, `"${fileName}"`, lineNumber, columnNumber)
     args.push.apply(args, extraArgs)
   } else {
-    args.push(fileName)
+    args.push(`"${fileName}"`)
   }
 
   if (_childProcess && isTerminalEditor(editor)) {
@@ -116,8 +116,8 @@ function launchEditor (file, specifiedEditor, onErrorCallback) {
     // launch .exe files.
     _childProcess = childProcess.spawn(
       'cmd.exe',
-      ['/C', editor].concat(args),
-      { stdio: 'inherit' }
+      ['/C start ""', `"${editor}"`].concat(args),
+      { shell: true, stdio: 'inherit' }
     )
   } else {
     _childProcess = childProcess.spawn(editor, args, { stdio: 'inherit' })


### PR DESCRIPTION
### What was fixed?
When my vscode installation directory contains spaces, using the ```vue-devtools``` "open in editor" function reports the following error:
![image](https://user-images.githubusercontent.com/23536402/215254731-f2e05061-d06a-4645-80b0-b321be0baa15.png)

I modified the source code to make it work again.

### Tips
I tried both ```'/C start""'``` and ```'/C start``` and they had the same effect.
I have only tested the ``win32`` environment, which is not sufficient. (I can't do any more testing, so I hope someone will help me finish it.)

### Reference
* https://blog.csdn.net/u011968063/article/details/50323239
