### PR TITLE
fix path with whitespace and fix "spawn" in vscode

### DIFF
--- a/packages/launch-editor/index.js
+++ b/packages/launch-editor/index.js
@@ -121,7 +121,7 @@ function launchEditor (file, specifiedEditor, onErrorCallback) {
     // launch .exe files.
     _childProcess = childProcess.spawn(
       'cmd.exe',
-      ['/C', editor].concat(args),
+      ['/C start ""', `"${editor}"`].concat(args),
       { stdio: 'inherit' }
     )
   } else if (editor === 'code' || editor.includes('Visual Studio Code.app')) {

--- a/packages/launch-editor/package.json
+++ b/packages/launch-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "launch-editor",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "description": "launch editor from node.js",
   "main": "index.js",
   "repository": {

--- a/packages/launch-editor/test.js
+++ b/packages/launch-editor/test.js
@@ -1,0 +1,3 @@
+const launchEditor = require('./index')
+
+launchEditor('/Volumes/dev/launch-editor/packages/launch-editor/index.js:11:5', '"/Users/zhuangjunlin/Desktop/Visual Studio Code.app/Contents/MacOS/Electron"')


### PR DESCRIPTION
1. fix the problem of error when there are spaces in the path
2. Error 'error error: spawn code enoent' will be thrown in the vscode environment, so 'exec' is used