### PR TITLE
fix(linux): check for more specific names first

### DIFF
--- a/packages/launch-editor/editor-info/linux.js
+++ b/packages/launch-editor/editor-info/linux.js
@@ -1,10 +1,10 @@
 module.exports = {
   atom: 'atom',
   Brackets: 'brackets',
-  code: 'code',
   'code-insiders': 'code-insiders',
-  codium: 'codium',
+  code: 'code',
   vscodium: 'vscodium',
+  codium: 'codium',
   emacs: 'emacs',
   gvim: 'gvim',
   'idea.sh': 'idea',


### PR DESCRIPTION
Because some names are substrings of other names, the more specific one must come first, otherwise the less specific one will override it. For example, `code-insiders` would be misidentified as `code`.