### PR TITLE
feat: update IntelliJ IDEA executable name for macOS

### DIFF
--- a/packages/launch-editor/editor-info/osx.js
+++ b/packages/launch-editor/editor-info/osx.js
@@ -21,6 +21,10 @@ module.exports = {
     '/Applications/CLion.app/Contents/MacOS/clion',
   '/Applications/IntelliJ IDEA.app/Contents/MacOS/idea':
     '/Applications/IntelliJ IDEA.app/Contents/MacOS/idea',
+  '/Applications/IntelliJ IDEA Ultimate.app/Contents/MacOS/idea':
+    '/Applications/IntelliJ IDEA Ultimate.app/Contents/MacOS/idea',
+  '/Applications/IntelliJ IDEA Community Edition.app/Contents/MacOS/idea':
+    '/Applications/IntelliJ IDEA Community Edition.app/Contents/MacOS/idea',
   '/Applications/PhpStorm.app/Contents/MacOS/phpstorm':
     '/Applications/PhpStorm.app/Contents/MacOS/phpstorm',
   '/Applications/PyCharm.app/Contents/MacOS/pycharm':


### PR DESCRIPTION
This PR adds new IntelliJ IDEA executable names to editor-info.

It seems that the IntelliJ IDEA executable name has been changed and separared into IntelliJ IDEA Ultimate and IntelliJ IDEA Community.