### PR TITLE
fix: strict exact match of macOS process

### DIFF
--- a/packages/launch-editor/guess.js
+++ b/packages/launch-editor/guess.js
@@ -37,7 +37,7 @@ module.exports = function guessEditor (specifiedEditor) {
       for (let i = 0; i < processNames.length; i++) {
         const processName = processNames[i]
         // Find editor by exact match.
-        if (output.indexOf(processName) !== -1) {
+        if (processList.includes(processName)) {
           return [COMMON_EDITORS_OSX[processName]]
         }
         const processNameWithoutApplications = processName.replace('/Applications', '')


### PR DESCRIPTION
This PR fixes a problem in which the search is not strictly an exact match in the part that searches for processes with an exact match.

In case running processes includes `/Users/foo/Applications/IntelliJ IDEA.app/Contents/MacOS/idea`, the original code will match this as well, since `COMMON_EDITORS_OSX` contains `/Applications/IntelliJ IDEA.app/Contents/MacOS/idea`.
This prevents finding editor installation not in `/Applications`, such as `/Users/foo/Applications/**`.

I addressed this by doing an exact match search on a `\n` separated list of `output` string.

This fixes #52.