### PR TITLE
feat: add support for Cursor editor `cursor` shell command in get-args.js

### DIFF
--- a/packages/launch-editor/get-args.js
+++ b/packages/launch-editor/get-args.js
@@ -38,6 +38,7 @@ module.exports = function getArgumentsForPosition (
     case 'code-insiders':
     case 'Code - Insiders':
     case 'codium':
+    case 'cursor':
     case 'vscodium':
     case 'VSCodium':
       return ['-r', '-g', `${fileName}:${lineNumber}:${columnNumber}`]


### PR DESCRIPTION
Adds support for Cursor editor (https://cursor.sh)