### PR TITLE
chore: update Jetbrains Linux commands

### DIFF
--- a/packages/launch-editor/editor-info/linux.js
+++ b/packages/launch-editor/editor-info/linux.js
@@ -7,13 +7,20 @@ module.exports = {
   codium: 'codium',
   emacs: 'emacs',
   gvim: 'gvim',
+  idea: 'idea',
   'idea.sh': 'idea',
+  phpstorm: 'phpstorm',
   'phpstorm.sh': 'phpstorm',
+  pycharm: 'pycharm',
   'pycharm.sh': 'pycharm',
+  rubymine: 'rubymine',
   'rubymine.sh': 'rubymine',
   sublime_text: 'subl',
   vim: 'vim',
+  webstorm: 'webstorm',
   'webstorm.sh': 'webstorm',
+  goland: 'goland',
   'goland.sh': 'goland',
+  rider: 'rider'
   'rider.sh': 'rider'
 }


### PR DESCRIPTION
Jetbrains IDEs now run their binary directly and show up in `ps` without the ".sh".
I believe this may not be the case for all installs so keeping the sh versions still makes sense.