### PR TITLE
fix: update regex to allow whitespace & `+` in Windows path

### DIFF
--- a/packages/launch-editor/index.js
+++ b/packages/launch-editor/index.js
@@ -106,7 +106,7 @@ function launchEditor (file, specifiedEditor, onErrorCallback) {
   // and
   // https://github.com/facebook/create-react-app/pull/5431)
 
-  // Allows alphanumeric characters, periods, dashes, slashes, and underscores.
+  // Allows alphanumeric characters, periods, dashes, slashes, underscores, plus and space.
   const WINDOWS_CMD_SAFE_FILE_NAME_PATTERN = /^([A-Za-z]:[/\\])?[\p{L}0-9/.\-_\\\s]+$/u
   if (
     process.platform === 'win32' &&

--- a/packages/launch-editor/index.js
+++ b/packages/launch-editor/index.js
@@ -107,7 +107,7 @@ function launchEditor (file, specifiedEditor, onErrorCallback) {
   // https://github.com/facebook/create-react-app/pull/5431)
 
   // Allows alphanumeric characters, periods, dashes, slashes, underscores, plus and space.
-  const WINDOWS_CMD_SAFE_FILE_NAME_PATTERN = /^([A-Za-z]:[/\\])?[\p{L}0-9/.\-_\\\s]+$/u
+  const WINDOWS_CMD_SAFE_FILE_NAME_PATTERN = /^([A-Za-z]:[/\\])?[\p{L}0-9/.\-+_\\\s]+$/u
   if (
     process.platform === 'win32' &&
     !WINDOWS_CMD_SAFE_FILE_NAME_PATTERN.test(fileName.trim())

--- a/packages/launch-editor/index.js
+++ b/packages/launch-editor/index.js
@@ -107,7 +107,7 @@ function launchEditor (file, specifiedEditor, onErrorCallback) {
   // https://github.com/facebook/create-react-app/pull/5431)
 
   // Allows alphanumeric characters, periods, dashes, slashes, and underscores.
-  const WINDOWS_CMD_SAFE_FILE_NAME_PATTERN = /^([A-Za-z]:[/\\])?[\p{L}0-9/.\-_\\]+$/u
+  const WINDOWS_CMD_SAFE_FILE_NAME_PATTERN = /^([A-Za-z]:[/\\])?[\p{L}0-9/.\-_\\\s]+$/u
   if (
     process.platform === 'win32' &&
     !WINDOWS_CMD_SAFE_FILE_NAME_PATTERN.test(fileName.trim())

--- a/packages/launch-editor/index.js
+++ b/packages/launch-editor/index.js
@@ -107,7 +107,7 @@ function launchEditor (file, specifiedEditor, onErrorCallback) {
   // https://github.com/facebook/create-react-app/pull/5431)
 
   // Allows alphanumeric characters, periods, dashes, slashes, underscores, plus and space.
-  const WINDOWS_CMD_SAFE_FILE_NAME_PATTERN = /^([A-Za-z]:[/\\])?[\p{L}0-9/.\-+_\\\s]+$/u
+  const WINDOWS_CMD_SAFE_FILE_NAME_PATTERN = /^([A-Za-z]:[/\\])?[\p{L}0-9/.\-\\_+ ]+$/u
   if (
     process.platform === 'win32' &&
     !WINDOWS_CMD_SAFE_FILE_NAME_PATTERN.test(fileName.trim())


### PR DESCRIPTION
Updated regex to authorize whitespace in file path.

Many projects has a whitespace in folder name (like me). Many time it doesn't affect anything but here it prevent file to open.

Let me know !