### PR TITLE
fix: update regex to include square brackets in file names

### DIFF
--- a/packages/launch-editor/index.js
+++ b/packages/launch-editor/index.js
@@ -107,7 +107,7 @@ function launchEditor (file, specifiedEditor, onErrorCallback) {
   // https://github.com/facebook/create-react-app/pull/5431)
 
   // Allows alphanumeric characters, periods, dashes, slashes, underscores, plus and space.
-  const WINDOWS_CMD_SAFE_FILE_NAME_PATTERN = /^([A-Za-z]:[/\\])?[\p{L}0-9/.\-\\_+ ]+$/u
+  const WINDOWS_CMD_SAFE_FILE_NAME_PATTERN = /^([A-Za-z]:[/\\])?[\p{L}0-9/.\-\\_+ \[\]]+$/u
   if (
     process.platform === 'win32' &&
     !WINDOWS_CMD_SAFE_FILE_NAME_PATTERN.test(fileName.trim())


### PR DESCRIPTION
Adjust the regex pattern for Windows to allow square brackets in file names. This change ensures compatibility with file names that contain these characters on the Windows platform.

Path as "pages\contest\[contest]\index.vue" valid in window.