### PR TITLE
fix: compatible for windows path with Chinese characters

### DIFF
--- a/packages/launch-editor/guess.js
+++ b/packages/launch-editor/guess.js
@@ -56,6 +56,8 @@ module.exports = function guessEditor (specifiedEditor) {
         }
       }
     } else if (process.platform === 'win32') {
+      // 防止中文路径乱码
+      childProcess.execSync('chcp 65001');
       const output = childProcess
         .execSync(
           'powershell -NoProfile -Command "Get-CimInstance -Query \\"select executablepath from win32_process where executablepath is not null\\" | % { $_.ExecutablePath }"',

--- a/packages/launch-editor/guess.js
+++ b/packages/launch-editor/guess.js
@@ -56,7 +56,7 @@ module.exports = function guessEditor (specifiedEditor) {
         }
       }
     } else if (process.platform === 'win32') {
-      // 防止中文路径乱码
+      // compatible for path with Chinese characters
       childProcess.execSync('chcp 65001');
       const output = childProcess
         .execSync(

--- a/packages/launch-editor/guess.js
+++ b/packages/launch-editor/guess.js
@@ -56,11 +56,12 @@ module.exports = function guessEditor (specifiedEditor) {
         }
       }
     } else if (process.platform === 'win32') {
-      // compatible for path with Chinese characters
-      childProcess.execSync('chcp 65001');
       const output = childProcess
         .execSync(
-          'powershell -NoProfile -Command "Get-CimInstance -Query \\"select executablepath from win32_process where executablepath is not null\\" | % { $_.ExecutablePath }"',
+          'powershell -NoProfile -Command "' +
+            '[Console]::OutputEncoding=[Text.Encoding]::UTF8;' +
+            'Get-CimInstance -Query \\"select executablepath from win32_process where executablepath is not null\\" | % { $_.ExecutablePath }' +
+            '"',
           {
             stdio: ['pipe', 'pipe', 'ignore']
           }

--- a/packages/launch-editor/index.js
+++ b/packages/launch-editor/index.js
@@ -157,9 +157,6 @@ function launchEditor (file, specifiedEditor, onErrorCallback) {
       .map(doubleQuoteIfNeeded)
       .join(' ')
     
-    // 防止中文路径乱码
-    childProcess.execSync('chcp 65001');
-    
     _childProcess = childProcess.exec(launchCommand, {
       stdio: 'inherit',
       shell: true

--- a/packages/launch-editor/index.js
+++ b/packages/launch-editor/index.js
@@ -156,7 +156,10 @@ function launchEditor (file, specifiedEditor, onErrorCallback) {
     const launchCommand = [editor, ...args.map(escapeCmdArgs)]
       .map(doubleQuoteIfNeeded)
       .join(' ')
-
+    
+    // 防止中文路径乱码
+    childProcess.execSync('chcp 65001');
+    
     _childProcess = childProcess.exec(launchCommand, {
       stdio: 'inherit',
       shell: true

--- a/packages/launch-editor/index.js
+++ b/packages/launch-editor/index.js
@@ -156,7 +156,7 @@ function launchEditor (file, specifiedEditor, onErrorCallback) {
     const launchCommand = [editor, ...args.map(escapeCmdArgs)]
       .map(doubleQuoteIfNeeded)
       .join(' ')
-    
+
     _childProcess = childProcess.exec(launchCommand, {
       stdio: 'inherit',
       shell: true


### PR DESCRIPTION
close #82 

On windows, when the path has Chinese characters, the output of processes from powershell will has messy code.

So before exec `powershell -NoProfile -Command "Get-CimInstance -Query \\"select executablepath from win32_process where executablepath is not null\\" | % { $_.ExecutablePath }"`. We need exec `chcp 65001` to make the output compatible for Chinese characters firstly.
