### PR TITLE
feat: Add TypeScript definition for launch-editor

### DIFF
--- a/packages/launch-editor/index.d.ts
+++ b/packages/launch-editor/index.d.ts
@@ -1,0 +1,16 @@
+/**
+ * Launch an editor to open a file at a specific line and column.
+ *
+ * @param file File path with optional line and column numbers (e.g.
+ *   "/path/to/file.js:10:2").
+ * @param specifiedEditor Optional editor command or path to use. Will be
+ *   parsed using `shell-quote`.
+ * @param onErrorCallback Optional callback for handling errors.
+ */
+declare function launchEditor(
+  file: string,
+  specifiedEditor?: string | ((fileName: string, errorMessage: string | null) => void),
+  onErrorCallback?: (fileName: string, errorMessage: string | null) => void
+): void;
+
+export = launchEditor;


### PR DESCRIPTION
### Context

I'm aiming to depend on `launch-editor` in https://github.com/react-native-community/cli/pull/2587. Having a TypeScript interface for this package will help this use case and the ecosystem.

### Changes

- Add `packages/launch-editor/index.d.ts`.

### Test plan

- Copy changes into existing `node_modules` install
- ✅ Parsed by language server

<img width="500" alt="image" src="https://github.com/user-attachments/assets/1c7dde41-db64-44e1-ad4e-0071cdd7cf58" />
