### PR TITLE
fix: support file URIs for middleware

### DIFF
--- a/packages/launch-editor-middleware/index.js
+++ b/packages/launch-editor-middleware/index.js
@@ -21,7 +21,8 @@ module.exports = (specifiedEditor, srcRoot, onErrorCallback) => {
       res.statusCode = 500
       res.end(`launch-editor-middleware: required query param "file" is missing.`)
     } else {
-      launch(path.resolve(srcRoot, file), specifiedEditor, onErrorCallback)
+      const resolved = file.startsWith('file://') ? file : path.resolve(srcRoot, file)
+      launch(resolved, specifiedEditor, onErrorCallback)
       res.end()
     }
   }


### PR DESCRIPTION
Since the file query was passed to `path.resolve(srcRoot, file)`, file urls did not work when using `launch-editor-middleware`. This PR fixes that.

refs #53 #91 