### PR TITLE
fix: use `URL` for parsing request URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "packageManager": "pnpm@10.4.1",
   "private": true,
   "scripts": {
+    "test": "pnpm -r test",
     "version-all": "pnpm -r exec npm version",
     "publish-all": "pnpm -r publish",
     "lint": "eslint packages --fix"

--- a/packages/launch-editor-middleware/index.js
+++ b/packages/launch-editor-middleware/index.js
@@ -1,4 +1,3 @@
-const url = require('url')
 const path = require('path')
 const launch = require('launch-editor')
 
@@ -16,7 +15,18 @@ module.exports = (specifiedEditor, srcRoot, onErrorCallback) => {
   srcRoot = srcRoot || process.cwd()
 
   return function launchEditorMiddleware (req, res) {
-    const { file } = url.parse(req.url, true).query || {}
+    let url;
+
+    try {
+      url = new URL(req.url);
+    // eslint-disable-next-line no-unused-vars
+    } catch (_err) {
+      res.statusCode = 500;
+      res.end(`launch-editor-middleware: invalid URL.`)
+      return;
+    }
+
+    const file = url.searchParams.get("file");
     if (!file) {
       res.statusCode = 500
       res.end(`launch-editor-middleware: required query param "file" is missing.`)

--- a/packages/launch-editor-middleware/index.js
+++ b/packages/launch-editor-middleware/index.js
@@ -14,22 +14,24 @@ module.exports = (specifiedEditor, srcRoot, onErrorCallback) => {
 
   srcRoot = srcRoot || process.cwd()
 
-  return function launchEditorMiddleware (req, res) {
-    let url;
+  return function launchEditorMiddleware(req, res) {
+    let url
 
     try {
-      url = new URL(req.url);
-    // eslint-disable-next-line no-unused-vars
+      url = new URL(req.url)
+      // eslint-disable-next-line no-unused-vars
     } catch (_err) {
-      res.statusCode = 500;
+      res.statusCode = 500
       res.end(`launch-editor-middleware: invalid URL.`)
-      return;
+      return
     }
 
-    const file = url.searchParams.get("file");
+    const file = url.searchParams.get('file')
     if (!file) {
       res.statusCode = 500
-      res.end(`launch-editor-middleware: required query param "file" is missing.`)
+      res.end(
+        `launch-editor-middleware: required query param "file" is missing.`
+      )
     } else {
       launch(path.resolve(srcRoot, file), specifiedEditor, onErrorCallback)
       res.end()

--- a/packages/launch-editor-middleware/index.test.js
+++ b/packages/launch-editor-middleware/index.test.js
@@ -8,9 +8,10 @@ mock.module('launch-editor', {
 })
 const launchEditorMiddleware = require('./index.js');
 
+const STATUS_NOT_ALTERED = -1; 
 class MockResponse {
   constructor() {
-    this.statusCode = -1;
+    this.statusCode = STATUS_NOT_ALTERED;
     this.body = '';
   }
 
@@ -55,8 +56,7 @@ describe('launchEditorMiddleware', () => {
 
     middleware(req, res);
 
-    // -1 here means it was never set
-    assert.equal(res.statusCode, -1);
+    assert.equal(res.statusCode, STATUS_NOT_ALTERED);
     assert.equal(res.body, '');
   });
 

--- a/packages/launch-editor-middleware/index.test.js
+++ b/packages/launch-editor-middleware/index.test.js
@@ -1,8 +1,12 @@
 const assert = require('node:assert/strict');
-const {describe, test} = require('node:test');
-const launchEditorMiddleware = require('./index.js');
+const {describe, test, mock} = require('node:test');
 
 const noop = () => {};
+
+mock.module('launch-editor', {
+  defaultExport: noop
+})
+const launchEditorMiddleware = require('./index.js');
 
 class MockResponse {
   constructor() {
@@ -45,7 +49,6 @@ describe('launchEditorMiddleware', () => {
       noop
     );
 
-    // this purposely doesn't exist so the launcher will bail early
     const file = 'mock/file:100';
     const req = new MockRequest(`https://localhost/?file=${file}`);
     const res = new MockResponse(null);

--- a/packages/launch-editor-middleware/index.test.js
+++ b/packages/launch-editor-middleware/index.test.js
@@ -1,0 +1,91 @@
+const assert = require('node:assert/strict');
+const {describe, test} = require('node:test');
+const launchEditorMiddleware = require('./index.js');
+
+const noop = () => {};
+
+class MockResponse {
+  constructor() {
+    this.statusCode = -1;
+    this.body = '';
+  }
+
+  end(body) {
+    this.body = body || '';
+  }
+}
+
+class MockRequest {
+  constructor(url) {
+    this.url = url;
+  }
+}
+
+describe('launchEditorMiddleware', () => {
+  test('returns a 500 if no file query param', async () => {
+    const middleware = launchEditorMiddleware(
+      'vim',
+      undefined,
+      noop
+    );
+
+    const req = new MockRequest('https://localhost/');
+    const res = new MockResponse(null);
+
+    middleware(req, res);
+
+    assert.equal(res.statusCode, 500);
+    assert.equal(res.body, 'launch-editor-middleware: required query param "file" is missing.');
+  });
+
+  test('launches editor with specified file', async () => {
+    const middleware = launchEditorMiddleware(
+      'vim',
+      undefined,
+      noop
+    );
+
+    // this purposely doesn't exist so the launcher will bail early
+    const file = 'mock/file:100';
+    const req = new MockRequest(`https://localhost/?file=${file}`);
+    const res = new MockResponse(null);
+
+    middleware(req, res);
+
+    // -1 here means it was never set
+    assert.equal(res.statusCode, -1);
+    assert.equal(res.body, '');
+  });
+
+  test('falsy file parameter returns 500', async () => {
+    const middleware = launchEditorMiddleware(
+      'vim',
+      undefined,
+      noop
+    );
+
+    const req = new MockRequest('https://localhost/?file=');
+    const res = new MockResponse(null);
+
+    middleware(req, res);
+
+    assert.equal(res.statusCode, 500);
+    assert.equal(res.body, 'launch-editor-middleware: required query param "file" is missing.');
+  });
+
+  test('returns 500 on invalid URL', async () => {
+    const middleware = launchEditorMiddleware(
+      'vim',
+      undefined,
+      noop
+    );
+
+    const req = new MockRequest('some invalid URL');
+    const res = new MockResponse(null);
+
+    middleware(req, res);
+
+    assert.equal(res.statusCode, 500);
+    assert.equal(res.body, 'launch-editor-middleware: invalid URL.');
+  });
+});

--- a/packages/launch-editor-middleware/index.test.js
+++ b/packages/launch-editor-middleware/index.test.js
@@ -1,94 +1,84 @@
-const assert = require('node:assert/strict');
-const {describe, test, mock} = require('node:test');
+const assert = require('node:assert/strict')
+const { describe, test, mock } = require('node:test')
 
-const noop = () => {};
+const noop = () => {}
 
 mock.module('launch-editor', {
-  defaultExport: noop
+  defaultExport: noop,
 })
-const launchEditorMiddleware = require('./index.js');
+const launchEditorMiddleware = require('./index.js')
 
-const STATUS_NOT_ALTERED = -1; 
+const STATUS_NOT_ALTERED = -1
 class MockResponse {
   constructor() {
-    this.statusCode = STATUS_NOT_ALTERED;
-    this.body = '';
+    this.statusCode = STATUS_NOT_ALTERED
+    this.body = ''
   }
 
   end(body) {
-    this.body = body || '';
+    this.body = body || ''
   }
 }
 
 class MockRequest {
   constructor(url) {
-    this.url = url;
+    this.url = url
   }
 }
 
 describe('launchEditorMiddleware', () => {
   test('returns a 500 if no file query param', async () => {
-    const middleware = launchEditorMiddleware(
-      'vim',
-      undefined,
-      noop
-    );
+    const middleware = launchEditorMiddleware('vim', undefined, noop)
 
-    const req = new MockRequest('https://localhost/');
-    const res = new MockResponse(null);
+    const req = new MockRequest('https://localhost/')
+    const res = new MockResponse(null)
 
-    middleware(req, res);
+    middleware(req, res)
 
-    assert.equal(res.statusCode, 500);
-    assert.equal(res.body, 'launch-editor-middleware: required query param "file" is missing.');
-  });
+    assert.equal(res.statusCode, 500)
+    assert.equal(
+      res.body,
+      'launch-editor-middleware: required query param "file" is missing.'
+    )
+  })
 
   test('launches editor with specified file', async () => {
-    const middleware = launchEditorMiddleware(
-      'vim',
-      undefined,
-      noop
-    );
+    const middleware = launchEditorMiddleware('vim', undefined, noop)
 
-    const file = 'mock/file:100';
-    const req = new MockRequest(`https://localhost/?file=${file}`);
-    const res = new MockResponse(null);
+    const file = 'mock/file:100'
+    const req = new MockRequest(`https://localhost/?file=${file}`)
+    const res = new MockResponse(null)
 
-    middleware(req, res);
+    middleware(req, res)
 
-    assert.equal(res.statusCode, STATUS_NOT_ALTERED);
-    assert.equal(res.body, '');
-  });
+    assert.equal(res.statusCode, STATUS_NOT_ALTERED)
+    assert.equal(res.body, '')
+  })
 
   test('falsy file parameter returns 500', async () => {
-    const middleware = launchEditorMiddleware(
-      'vim',
-      undefined,
-      noop
-    );
+    const middleware = launchEditorMiddleware('vim', undefined, noop)
 
-    const req = new MockRequest('https://localhost/?file=');
-    const res = new MockResponse(null);
+    const req = new MockRequest('https://localhost/?file=')
+    const res = new MockResponse(null)
 
-    middleware(req, res);
+    middleware(req, res)
 
-    assert.equal(res.statusCode, 500);
-    assert.equal(res.body, 'launch-editor-middleware: required query param "file" is missing.');
-  });
+    assert.equal(res.statusCode, 500)
+    assert.equal(
+      res.body,
+      'launch-editor-middleware: required query param "file" is missing.'
+    )
+  })
 
   test('returns 500 on invalid URL', async () => {
-    const middleware = launchEditorMiddleware(
-      'vim',
-      undefined,
-      noop
-    );
+    const middleware = launchEditorMiddleware('vim', undefined, noop)
 
-    const req = new MockRequest('some invalid URL');
-    const res = new MockResponse(null);
+    const req = new MockRequest('some invalid URL')
+    const res = new MockResponse(null)
 
-    middleware(req, res);
+    middleware(req, res)
 
-    assert.equal(res.statusCode, 500);
-    assert.equal(res.body, 'launch-editor-middleware: invalid URL.');
-  });
-});
+    assert.equal(res.statusCode, 500)
+    assert.equal(res.body, 'launch-editor-middleware: invalid URL.')
+  })
+})

--- a/packages/launch-editor-middleware/package.json
+++ b/packages/launch-editor-middleware/package.json
@@ -3,6 +3,12 @@
   "version": "2.10.0",
   "description": "express middleware for launching editor",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
+  "scripts": {
+    "test": "node --test"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/yyx990803/launch-editor.git"

--- a/packages/launch-editor-middleware/package.json
+++ b/packages/launch-editor-middleware/package.json
@@ -7,7 +7,7 @@
     "index.js"
   ],
   "scripts": {
-    "test": "node --test"
+    "test": "node --test --experimental-test-module-mocks"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Switches to using the `URL` constructor and adds a few tests.
