### PR TITLE
Added Visual Studio support for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To launch files, send requests to the server like the following:
 | `rubymine`      | [RubyMine](https://www.jetbrains.com/ruby/)                            |  ✓    |   ✓     |   ✓   |
 | `sublime`       | [Sublime Text](https://www.sublimetext.com/)                           |  ✓    |   ✓     |   ✓   |
 | `vim`           | [Vim](http://www.vim.org/)                                             |  ✓    |         |       |
-| `visualstudio`  | [Visual Studio](https://www.visualstudio.com/vs/)                      |       |         |   ✓   |
+| `visualstudio`  | [Visual Studio](https://www.visualstudio.com/vs/)                      |       |   ✓     |   ✓   |
 | `webstorm`      | [WebStorm](https://www.jetbrains.com/webstorm/)                        |  ✓    |   ✓     |   ✓   |
 | `zed`           | [Zed](https://zed.dev/)                                                |  ✓    |         |   ✓   |
 

--- a/packages/launch-editor/editor-info/windows.js
+++ b/packages/launch-editor/editor-info/windows.js
@@ -23,5 +23,6 @@ module.exports = [
   'goland64.exe',
   'rider.exe',
   'rider64.exe',
-  'trae.exe'
+  'trae.exe',
+  'devenv.exe'
 ]

--- a/packages/launch-editor/get-args.js
+++ b/packages/launch-editor/get-args.js
@@ -62,6 +62,9 @@ module.exports = function getArgumentsForPosition (
     case 'rider':
     case 'rider64':
       return ['--line', lineNumber, '--column', columnNumber, fileName]
+    case 'devenv':
+    case 'visualstudio':
+      return ['/edit', fileName]
   }
 
   if (process.env.LAUNCH_EDITOR) {

--- a/packages/launch-editor/get-args.test.js
+++ b/packages/launch-editor/get-args.test.js
@@ -1,0 +1,30 @@
+const assert = require('node:assert/strict')
+const { describe, test } = require('node:test')
+const getArgumentsForPosition = require('./get-args.js')
+
+describe('getArgumentsForPosition', () => {
+  test('should format arguments for Visual Studio (devenv)', () => {
+    const result = getArgumentsForPosition('devenv.exe', 'test.js', 10, 5)
+    assert.deepEqual(result, ['/edit', 'test.js'])
+  })
+
+  test('should format arguments for Visual Studio (visualstudio)', () => {
+    const result = getArgumentsForPosition('visualstudio', 'src/app.js', 42, 12)
+    assert.deepEqual(result, ['/edit', 'src/app.js'])
+  })
+
+  test('should format arguments for Visual Studio with default column', () => {
+    const result = getArgumentsForPosition('devenv.exe', 'main.cpp', 100)
+    assert.deepEqual(result, ['/edit', 'main.cpp'])
+  })
+
+  test('should format arguments for VS Code for comparison', () => {
+    const result = getArgumentsForPosition('code.exe', 'test.js', 10, 5)
+    assert.deepEqual(result, ['-r', '-g', 'test.js:10:5'])
+  })
+
+  test('should format arguments for Notepad++ for comparison', () => {
+    const result = getArgumentsForPosition('notepad++.exe', 'test.txt', 15, 8)
+    assert.deepEqual(result, ['-n15', '-c8', 'test.txt'])
+  })
+})

--- a/packages/launch-editor/package.json
+++ b/packages/launch-editor/package.json
@@ -3,6 +3,9 @@
   "version": "2.11.1",
   "description": "launch editor from node.js",
   "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/yyx990803/launch-editor.git"


### PR DESCRIPTION
- Reusing the IDE window and jumping to a specific line number is not supported at the same time. Prefering to use the same window over jumping to a line number.
- Added test file for launch-editor.