### PR TITLE
fix: ensure correct argument formatting for cursor editor support

### DIFF
--- a/packages/launch-editor/get-args.js
+++ b/packages/launch-editor/get-args.js
@@ -40,10 +40,11 @@ module.exports = function getArgumentsForPosition (
     case 'Code - Insiders':
     case 'codium':
     case 'trae':
-    case 'cursor':
     case 'vscodium':
     case 'VSCodium':
       return ['-r', '-g', `${fileName}:${lineNumber}:${columnNumber}`]
+    case 'cursor':
+      return ['-r', '-g', `"${fileName}:${lineNumber}:${columnNumber}"`]
     case 'appcode':
     case 'clion':
     case 'clion64':


### PR DESCRIPTION
fix cursor cannot recognize the situation where the path contains special characters

[#107](https://github.com/yyx990803/launch-editor/issues/107)