### PR TITLE
fix: add canonical path for vscode insiders on macos

### DIFF
--- a/packages/launch-editor/editor-info/macos.js
+++ b/packages/launch-editor/editor-info/macos.js
@@ -11,7 +11,6 @@ module.exports = {
     '/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl',
   '/Applications/Sublime Text Dev.app/Contents/MacOS/Sublime Text':
     '/Applications/Sublime Text Dev.app/Contents/SharedSupport/bin/subl',
-  '/Applications/Visual Studio Code.app/Contents/MacOS/Code': 'code',
   '/Applications/Visual Studio Code.app/Contents/MacOS/Electron': 'code',
   '/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/Code - Insiders':
     'code-insiders',


### PR DESCRIPTION
`Electron` is a alias to `Code - Insiders`.