### PR TITLE
feat: add Windsurf support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ To launch files, send requests to the server like the following:
 | `code-insiders` | [Visual Studio Code Insiders](https://code.visualstudio.com/insiders/) |  ✓    |   ✓     |   ✓   |
 | `codium`        | [VSCodium](https://github.com/VSCodium/vscodium)                       |  ✓    |   ✓     |   ✓   |
 | `cursor`        | [Cursor](https://www.cursor.com/)                                      |  ✓    |   ✓     |   ✓   |
+| `windsurf`      | [Windsurf](https://windsurf.ai/)                                      |  ✓    |   ✓     |   ✓   |
 | `emacs`         | [Emacs](https://www.gnu.org/software/emacs/)                           |  ✓    |         |       |
 | `idea`          | [IDEA](https://www.jetbrains.com/idea/)                                |  ✓    |   ✓     |   ✓   |
 | `notepad++`     | [Notepad++](https://notepad-plus-plus.org/download/v7.5.4.html)        |       |   ✓     |       |

--- a/packages/launch-editor/editor-info/linux.js
+++ b/packages/launch-editor/editor-info/linux.js
@@ -26,5 +26,6 @@ module.exports = {
   'goland.sh': 'goland',
   rider: 'rider',
   'rider.sh': 'rider',
-  zed: 'zed'
+  zed: 'zed',
+  windsurf: 'windsurf'
 }

--- a/packages/launch-editor/editor-info/macos.js
+++ b/packages/launch-editor/editor-info/macos.js
@@ -46,5 +46,6 @@ module.exports = {
     '/Applications/GoLand.app/Contents/MacOS/goland',
   '/Applications/Rider.app/Contents/MacOS/rider':
     '/Applications/Rider.app/Contents/MacOS/rider',
-  '/Applications/Zed.app/Contents/MacOS/zed': 'zed'
+  '/Applications/Zed.app/Contents/MacOS/zed': 'zed',
+  '/Applications/Windsurf.app/Contents/MacOS/Windsurf': 'windsurf'
 }

--- a/packages/launch-editor/editor-info/windows.js
+++ b/packages/launch-editor/editor-info/windows.js
@@ -25,5 +25,6 @@ module.exports = [
   'rider64.exe',
   'Trae.exe',
   'zed.exe',
-  'Antigravity.exe'
+  'Antigravity.exe',
+  'Windsurf.exe'
 ]

--- a/packages/launch-editor/get-args.js
+++ b/packages/launch-editor/get-args.js
@@ -1,7 +1,7 @@
 const path = require('path')
 
 // normalize file/line numbers into command line args for specific editors
-module.exports = function getArgumentsForPosition (
+module.exports = function getArgumentsForPosition(
   editor,
   fileName,
   lineNumber,
@@ -44,6 +44,7 @@ module.exports = function getArgumentsForPosition (
     case 'cursor':
     case 'vscodium':
     case 'VSCodium':
+    case 'windsurf':
       return ['-r', '-g', `${fileName}:${lineNumber}:${columnNumber}`]
     case 'appcode':
     case 'clion':


### PR DESCRIPTION
This PR adds support for the Windsurf editor. Like VS Code, it supports the --goto flag for opening files at specific lines and columns.

Relates to [vuejs/devtools#873](https://github.com/vuejs/devtools/issues/873)