### PR TITLE
feat(launch-editor): add support for Trae CN editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ To launch files, send requests to the server like the following:
 | `vim`           | [Vim](http://www.vim.org/)                                             |  ✓    |         |       |
 | `visualstudio`  | [Visual Studio](https://www.visualstudio.com/vs/)                      |       |         |   ✓   |
 | `webstorm`      | [WebStorm](https://www.jetbrains.com/webstorm/)                        |  ✓    |   ✓     |   ✓   |
+| `trae`          | [Trae](https://www.trae.ai/)                                           |  ✓    |   ✓     |   ✓   |
+| `trae-cn`       | [Trae CN](https://www.trae.cn/)                                         |  ✓    |   ✓     |   ✓   |
 | `zed`           | [Zed](https://zed.dev/)                                                |  ✓    |   ✓     |   ✓   |
 
 ### Custom editor support

--- a/packages/launch-editor/editor-info/linux.js
+++ b/packages/launch-editor/editor-info/linux.js
@@ -7,6 +7,7 @@ module.exports = {
   codium: 'codium',
   cursor: 'cursor',
   trae: 'trae',
+  'trae-cn': 'trae-cn',
   antigravity: 'antigravity',
   emacs: 'emacs',
   gvim: 'gvim',

--- a/packages/launch-editor/editor-info/macos.js
+++ b/packages/launch-editor/editor-info/macos.js
@@ -20,6 +20,7 @@ module.exports = {
   '/Applications/VSCodium.app/Contents/MacOS/Electron': 'codium',
   '/Applications/Cursor.app/Contents/MacOS/Cursor': 'cursor',
   '/Applications/Trae.app/Contents/MacOS/Electron': 'trae',
+  '/Applications/Trae CN.app/Contents/MacOS/Electron': 'trae-cn',
   '/Applications/Antigravity.app/Contents/MacOS/Electron': 'antigravity',
   '/Applications/AppCode.app/Contents/MacOS/appcode':
     '/Applications/AppCode.app/Contents/MacOS/appcode',

--- a/packages/launch-editor/editor-info/windows.js
+++ b/packages/launch-editor/editor-info/windows.js
@@ -24,6 +24,7 @@ module.exports = [
   'rider.exe',
   'rider64.exe',
   'Trae.exe',
+  'Trae CN.exe',
   'zed.exe',
   'Antigravity.exe'
 ]

--- a/packages/launch-editor/get-args.js
+++ b/packages/launch-editor/get-args.js
@@ -1,7 +1,7 @@
 const path = require('path')
 
 // normalize file/line numbers into command line args for specific editors
-module.exports = function getArgumentsForPosition (
+module.exports = function getArgumentsForPosition(
   editor,
   fileName,
   lineNumber,
@@ -40,6 +40,7 @@ module.exports = function getArgumentsForPosition (
     case 'Code - Insiders':
     case 'codium':
     case 'trae':
+    case 'trae-cn':
     case 'antigravity':
     case 'cursor':
     case 'vscodium':


### PR DESCRIPTION
新增Trae CN编辑器的启动支持，适配Windows、Linux和macOS平台，更新README文档添加对应支持表格项